### PR TITLE
Improve thumbnail loading performance

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -74,16 +74,35 @@ class ApiClientImpl implements ApiClient {
   }
 
   // Images API
-  async getThumbnail(filePath: string, size: number = 200): Promise<string> {
+  async getThumbnail(filePath: string, size: number = 200, signal?: AbortSignal): Promise<string> {
     const params = `?size=${size}&format=PNG`;
-    const response = await fetch(`${API_BASE_URL}/images/thumbnail/${encodeURIComponent(filePath)}${params}`);
-    
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+
+    // Combine provided signal with an internal timeout for better responsiveness
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const onAbort = () => controller.abort();
+    if (signal) {
+      signal.addEventListener('abort', onAbort);
     }
 
-    const blob = await response.blob();
-    return URL.createObjectURL(blob);
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/images/thumbnail/${encodeURIComponent(filePath)}${params}`,
+        { signal: controller.signal }
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const blob = await response.blob();
+      return URL.createObjectURL(blob);
+    } finally {
+      clearTimeout(timeoutId);
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    }
   }
 
   async getPreview(filePath: string, format: string = 'PNG'): Promise<string> {

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -16,48 +16,16 @@ import { useAppStore, useCurrentDirectory, useSelectedFiles } from '../stores/ap
 
 // Thumbnail component for EXR files
 const Thumbnail: React.FC<{ filePath: string; size?: number }> = ({ filePath, size = 200 }) => {
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [imgError, setImgError] = useState(false);
 
-  React.useEffect(() => {
-    let isMounted = true;
-    
-    const loadThumbnail = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        
-        // Use a timeout to prevent blocking the UI
-        const timeoutPromise = new Promise((_, reject) => 
-          setTimeout(() => reject(new Error('Timeout')), 5000)
-        );
-        
-        const thumbnailPromise = apiClient.getThumbnail(filePath, size);
-        
-        const url = await Promise.race([thumbnailPromise, timeoutPromise]) as string;
-        
-        if (isMounted) {
-          setImageUrl(url);
-          setIsLoading(false);
-        }
-      } catch (err: any) {
-        if (isMounted) {
-          setError(err.message);
-          setIsLoading(false);
-        }
-      }
-    };
+  const { data: imageUrl, isPending, isError } = useQuery({
+    queryKey: ['thumbnail', filePath, size],
+    queryFn: ({ signal }) => apiClient.getThumbnail(filePath, size, signal),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  });
 
-    // Load thumbnail in background
-    loadThumbnail();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [filePath, size]);
-
-  // Cleanup on unmount
   React.useEffect(() => {
     return () => {
       if (imageUrl && imageUrl.startsWith('blob:')) {
@@ -66,28 +34,39 @@ const Thumbnail: React.FC<{ filePath: string; size?: number }> = ({ filePath, si
     };
   }, [imageUrl]);
 
-  if (isLoading) {
+  // Placeholder for loading state
+  if (isPending) {
     return (
-      <div className="w-16 h-16 bg-gray-700 rounded-lg flex items-center justify-center">
+      <div
+        className="bg-gray-700 rounded-lg flex items-center justify-center"
+        style={{ width: size, height: size }}
+      >
         <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-exr-accent"></div>
       </div>
     );
   }
 
-  if (error) {
+  // Error placeholder
+  if (isError || imgError) {
     return (
-      <div className="w-16 h-16 bg-gray-700 rounded-lg flex items-center justify-center">
+      <div
+        className="bg-gray-700 rounded-lg flex items-center justify-center"
+        style={{ width: size, height: size }}
+      >
         <PhotoIcon className="w-8 h-8 text-gray-400" />
       </div>
     );
   }
 
+  // Render image preserving aspect ratio within the requested size
   return (
     <img
       src={imageUrl!}
       alt="Thumbnail"
-      className="w-16 h-16 object-cover rounded-lg"
-      onError={() => setError('Failed to load thumbnail')}
+      style={{ maxWidth: size, maxHeight: size }}
+      className="rounded-lg"
+      loading="lazy"
+      onError={() => setImgError(true)}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Preserve thumbnail aspect ratio with size-aware placeholders and max dimension constraints
- Request full-size thumbnails in library view for sharper previews

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' due to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ef626ae48324ba5e36bc783acedf